### PR TITLE
Rework GitHub workflows

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -6,15 +6,15 @@ jobs:
     test:
         strategy:
             matrix:
-                version: ['stable', 'nightly']
+                version: ['1.56.0', 'stable', 'nightly']
         runs-on: [ubuntu-latest]
         timeout-minutes: 5
         steps:
             - uses: actions/checkout@v2
-            - name: Install latest Rust
+            - name: Install Rust
               uses: actions-rs/toolchain@v1
               with:
-                  toolchain: stable
+                  toolchain: ${{ matrix.version }}
                   profile: minimal
                   override: true
             - name: Test
@@ -27,12 +27,6 @@ jobs:
         timeout-minutes: 5
         steps:
             - uses: actions/checkout@v2
-            - name: Install latest Rust
-              uses: actions-rs/toolchain@v1
-              with:
-                  toolchain: stable
-                  profile: minimal
-                  override: true
             - name: Install latest nightly Rust
               uses: actions-rs/toolchain@v1
               with:


### PR DESCRIPTION
This change fixes the test job to properly test against multiple Rust versions, and adds the first version of Rust to support Rust 2021.