### PR TITLE
Bump to Rust 2021

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 coverage
 target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ include = [
 	"/LICENSE",
 	"/README.md"
 ]
-edition = "2018"
+edition = "2021"
 
 [lib]
 name = "captur"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,12 @@ fn send_event_and_action(action: &Action, event: Event) {
 }
 ```
 
+# Supported Rust Versions
+
+This project will support all Rust versions since 1.51, when Rust first supported Rust 2021.
+
+Dropping support for a Rust version will result in a major version bump, following [Semantic Versioning](https://semver.org/).
+
 ## License
 
 Captur is released under the ISC license. See [LICENSE](LICENSE).


### PR DESCRIPTION
Update the supported version of Rust to 2021, and make note of the supported Rust versions.