### PR TITLE
Run pull request workflow on merge to main

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,6 +1,11 @@
 name: Pull Request
 
-on: [pull_request]
+on:
+    pull_request:
+    # run CI/CD against main as well, to generate cache
+    push:
+        branches:
+            - main
 
 jobs:
     test:


### PR DESCRIPTION
In order for the CI cache to work during the PR pipeline, the pipeline also needs to run during the merge to main.